### PR TITLE
Limit installation to Linux platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It uses a tiny POSIX-compatible shell script to call `sbatch` and related comman
 
 - SLURM cluster with `sbatch`, `squeue`, and optionally `sacct` / `scontrol`
 - Python ≥ 3.9
+- Linux operating system
 
 ## Quickstart
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,13 @@ authors = [
 ]
 requires-python = ">=3.11"
 dependencies = []
+classifiers = ["Operating System :: POSIX :: Linux"]
 
 [project.scripts]
 nanoslurm = "nanoslurm:main"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling; sys_platform == 'linux'"]
 build-backend = "hatchling.build"
 
 [tool.ruff]

--- a/src/nanoslurm/__init__.py
+++ b/src/nanoslurm/__init__.py
@@ -1,2 +1,8 @@
+import sys
+
+if not sys.platform.startswith("linux"):
+    raise OSError("nanoslurm is only supported on Linux")
+
+
 def main() -> None:
     print("Hello from slurmkit!")


### PR DESCRIPTION
## Summary
- ensure package only builds on Linux by marking the build backend requirement
- document Linux-only support
- raise an error on import when not running on Linux

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2a46b98848326abc8a9ba28aab555