### PR TITLE
Add Textual TUI for job monitoring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nanoslurm"
-version = "0.1.1"
+version = "0.1.2"
 description = "Add your description here"
 readme = "README.md"
 authors = [
@@ -10,6 +10,7 @@ requires-python = ">=3.11"
 dependencies = [
     "typer",
     "rich",
+    "textual",
     "platformdirs",
     "pyyaml",
 ]

--- a/src/nanoslurm/cli.py
+++ b/src/nanoslurm/cli.py
@@ -114,6 +114,14 @@ def run(
         console.print(f"stderr: {job.stderr_path}")
 
 
+@app.command("jobs")
+def jobs() -> None:
+    """Launch a Textual TUI to view current user's jobs."""
+    from .tui import JobApp
+
+    JobApp().run()
+
+
 defaults_app = typer.Typer(help="Manage default settings")
 app.add_typer(defaults_app, name="defaults")
 

--- a/src/nanoslurm/tui.py
+++ b/src/nanoslurm/tui.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+
+from textual.app import App, ComposeResult
+from textual.widgets import DataTable, Footer, Header
+
+from .nanoslurm import _run, _which
+
+
+class JobApp(App):
+    """Textual app to display current user's SLURM jobs."""
+
+    BINDINGS = [("q", "quit", "Quit")]
+
+    def compose(self) -> ComposeResult:  # pragma: no cover - Textual composition
+        yield Header()
+        self.table: DataTable = DataTable()
+        yield self.table
+        yield Footer()
+
+    def on_mount(self) -> None:  # pragma: no cover - runtime hook
+        self.table.add_columns("ID", "Name", "State")
+        self.refresh_table()
+        self.set_interval(2.0, self.refresh_table)
+
+    def refresh_table(self) -> None:  # pragma: no cover - runtime hook
+        rows = _list_jobs()
+        self.table.clear()
+        for row in rows:
+            self.table.add_row(*row)
+
+
+def _list_jobs() -> list[tuple[str, str, str]]:
+    """Return a list of (id, name, state) for current user's jobs."""
+    if not _which("squeue"):
+        return []
+    user = os.environ.get("USER", "")
+    out = _run(["squeue", "-u", user, "-h", "-o", "%i|%j|%T"], check=False).stdout
+    rows: list[tuple[str, str, str]] = []
+    for line in out.splitlines():
+        parts = line.split("|")
+        if len(parts) == 3:
+            rows.append(tuple(parts))
+    return rows
+
+
+__all__ = ["JobApp"]

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,18 @@
+import types
+
+from nanoslurm.tui import _list_jobs
+
+
+def test_list_jobs_no_squeue(monkeypatch):
+    monkeypatch.setattr('nanoslurm.tui._which', lambda cmd: False)
+    assert _list_jobs() == []
+
+
+def test_list_jobs_parse(monkeypatch):
+    monkeypatch.setattr('nanoslurm.tui._which', lambda cmd: True)
+
+    def fake_run(cmd, check=False):
+        return types.SimpleNamespace(stdout="1|job1|RUNNING\n2|job2|PENDING\n")
+
+    monkeypatch.setattr('nanoslurm.tui._run', fake_run)
+    assert _list_jobs() == [("1", "job1", "RUNNING"), ("2", "job2", "PENDING")]


### PR DESCRIPTION
## Summary
- add Textual dependency
- add `JobApp` TUI to display current user's SLURM jobs
- expose TUI via new `nslurm jobs` command
- bump version to 0.1.2 and add tests for `_list_jobs`

## Testing
- `pip install -e .`
- `python -m ruff check`
- `pytest`
- `nslurm jobs --help`


------
https://chatgpt.com/codex/tasks/task_e_68c3f745f46483268a7cabe5cc727a71