### PR TITLE
fix GitHub Action warning for uv setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@v4
         with:
           python-version: "3.11"
       - name: Determine version change

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@v4
         with:
           python-version: "3.11"
       - name: Determine version change


### PR DESCRIPTION
## Summary
- update astral-sh/setup-uv to v4 in tag and release workflows

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3fb5040c8832682ccb7d530e6aa62