### PR TITLE
Handle duplicate PyPI releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,5 +40,5 @@ jobs:
           fi
       - run: uv build
         if: steps.version.outputs.changed == 'true'
-      - run: uv publish
+      - run: uv publish --check-url https://pypi.org/simple
         if: steps.version.outputs.changed == 'true'


### PR DESCRIPTION
## Summary
- check for existing files on PyPI before publishing

## Testing
- `PYTHONPATH=src uv run --with textual pytest` *(fails: ModuleNotFoundError: No module named 'textual')*

------
https://chatgpt.com/codex/tasks/task_e_68c405abe8d48326ba253273e0ddde1e