### PR TITLE
Handle missing SLURM commands and respect terminal theme

### DIFF
--- a/tests/test_slurm_env.py
+++ b/tests/test_slurm_env.py
@@ -1,0 +1,17 @@
+import pytest
+
+from nanoslurm.nanoslurm import Job, SlurmUnavailableError, submit
+
+
+def test_submit_no_sbatch(monkeypatch):
+    monkeypatch.setattr("nanoslurm.nanoslurm._which", lambda cmd: False)
+    with pytest.raises(SlurmUnavailableError):
+        submit(["echo"], cluster="c", time="0:10:00", cpus=1, memory=1, gpus=0)
+
+
+def test_job_status_no_slurm(monkeypatch):
+    monkeypatch.setattr("nanoslurm.nanoslurm._which", lambda cmd: False)
+
+    job = Job(id=1, name="j", stdout_path=None, stderr_path=None)
+    with pytest.raises(SlurmUnavailableError):
+        _ = job.status

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,11 +1,15 @@
 import types
 
+import pytest
+
+from nanoslurm.nanoslurm import SlurmUnavailableError
 from nanoslurm.tui import _list_jobs
 
 
 def test_list_jobs_no_squeue(monkeypatch):
     monkeypatch.setattr("nanoslurm.tui._which", lambda cmd: False)
-    assert _list_jobs() == []
+    with pytest.raises(SlurmUnavailableError):
+        _list_jobs()
 
 
 def test_list_jobs_parse(monkeypatch):


### PR DESCRIPTION
## Summary
- Raise `SlurmUnavailableError` when required SLURM commands are absent
- Simplify the job viewer TUI to avoid overriding terminal colors
- Add tests for missing SLURM environments

## Testing
- `ruff check src tests`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4072491348326addce059c24cdd23