### PR TITLE
ci: auto-tag version bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,9 @@
 name: Release
 
 on:
-  workflow_run:
-    workflows: ["Tag Version"]
-    types:
-      - completed
+  push:
+    tags:
+      - "v*"
 
 permissions:
   contents: read
@@ -16,29 +15,8 @@ jobs:
     environment: pypi
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
       - uses: astral-sh/setup-uv@v4
         with:
           python-version: "3.11"
-      - name: Determine version change
-        id: version
-        run: |
-          new_version=$(uv version --short)
-          echo "version=$new_version" >> "$GITHUB_OUTPUT"
-          tmp_dir=$(mktemp -d)
-          git show HEAD^:pyproject.toml 2>/dev/null > "$tmp_dir/pyproject.toml" || true
-          if [ -s "$tmp_dir/pyproject.toml" ]; then
-            old_version=$(uv version --short --project "$tmp_dir")
-          else
-            old_version=""
-          fi
-          if [ "$new_version" != "$old_version" ]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
       - run: uv build
-        if: steps.version.outputs.changed == 'true'
       - run: uv publish --check-url https://pypi.org/simple
-        if: steps.version.outputs.changed == 'true'

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,8 +1,9 @@
-name: Tag Version
+name: Tag version
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
 
 permissions:
   contents: write
@@ -17,7 +18,7 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           python-version: "3.11"
-      - name: Determine version change
+      - name: Detect version change
         id: version
         run: |
           new_version=$(uv version --short)
@@ -34,14 +35,15 @@ jobs:
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
-      - name: Create tag
+      - name: Push tag
         if: steps.version.outputs.changed == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch --tags
           if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
             echo "Tag v${{ steps.version.outputs.version }} already exists"
-          else
-            git tag "v${{ steps.version.outputs.version }}"
-            git push origin "v${{ steps.version.outputs.version }}"
+            exit 0
           fi
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git tag "v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## Summary
- automatically tag new releases on main after version changes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c40807f99883269972069515859758