### PR TITLE
Improve defaults set help messages

### DIFF
--- a/src/nanoslurm/__init__.py
+++ b/src/nanoslurm/__init__.py
@@ -5,6 +5,14 @@ import sys
 if not sys.platform.startswith("linux"):
     raise OSError("nanoslurm is only supported on Linux")
 
+from .defaults import DEFAULTS, KEY_TYPES, load_defaults, save_defaults
 from .nanoslurm import Job, submit
 
-__all__ = ["Job", "submit"]
+__all__ = [
+    "Job",
+    "submit",
+    "DEFAULTS",
+    "KEY_TYPES",
+    "load_defaults",
+    "save_defaults",
+]

--- a/src/nanoslurm/defaults.py
+++ b/src/nanoslurm/defaults.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import yaml
+from platformdirs import user_config_dir
+
+# Allowed keys and their types for default configuration
+KEY_TYPES: Dict[str, type] = {
+    "name": str,
+    "cluster": str,
+    "time": str,
+    "cpus": int,
+    "memory": int,
+    "gpus": int,
+    "stdout_file": str,
+    "stderr_file": str,
+    "signal": str,
+    "workdir": str,
+}
+
+# Minimal built-in defaults; most values must be supplied via CLI or config
+DEFAULTS: Dict[str, object] = {
+    "name": "job",
+    "stdout_file": "./slurm_logs/%j.txt",
+    "stderr_file": "./slurm_logs/%j.err",
+    "signal": "SIGUSR1@90",
+    "workdir": ".",
+}
+
+CONFIG_PATH = Path(user_config_dir("nanoslurm")) / "config.yaml"
+
+
+def load_defaults() -> Dict[str, object]:
+    """Return defaults merged with any saved configuration."""
+    data = DEFAULTS.copy()
+    if CONFIG_PATH.exists():
+        try:
+            loaded = yaml.safe_load(CONFIG_PATH.read_text()) or {}
+            if isinstance(loaded, dict):
+                data.update(loaded)
+        except Exception:
+            pass
+    return data
+
+
+def save_defaults(cfg: Dict[str, object]) -> None:
+    """Persist provided configuration to :data:`CONFIG_PATH`."""
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CONFIG_PATH.write_text(yaml.safe_dump(cfg, sort_keys=False))
+
+
+KEY_HELP = ", ".join(f"{k} ({t.__name__})" for k, t in KEY_TYPES.items())

--- a/tests/test_defaults_cli.py
+++ b/tests/test_defaults_cli.py
@@ -1,0 +1,27 @@
+from typer.testing import CliRunner
+from nanoslurm.cli import app
+
+runner = CliRunner()
+
+
+def test_defaults_set_help_lists_keys():
+    result = runner.invoke(app, ["defaults", "set", "--help"])
+    assert result.exit_code == 0
+    assert "Configuration key to set" in result.output
+    assert "name (str)" in result.output
+    assert "cpus (int)" in result.output
+
+
+def test_defaults_set_unknown_key_error(tmp_path):
+    env = {"XDG_CONFIG_HOME": str(tmp_path)}
+    result = runner.invoke(app, ["defaults", "set", "foo", "bar"], env=env)
+    assert result.exit_code != 0
+    assert "Unknown key: foo" in result.output
+    assert "Allowed keys" in result.output
+
+
+def test_defaults_set_type_error(tmp_path):
+    env = {"XDG_CONFIG_HOME": str(tmp_path)}
+    result = runner.invoke(app, ["defaults", "set", "cpus", "notint"], env=env)
+    assert result.exit_code != 0
+    assert "cpus expects type int" in result.output

--- a/tests/test_defaults_module.py
+++ b/tests/test_defaults_module.py
@@ -1,0 +1,12 @@
+from nanoslurm import DEFAULTS, KEY_TYPES, load_defaults, save_defaults
+
+
+def test_roundtrip_load_save(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    cfg = load_defaults()
+    assert cfg["name"] == DEFAULTS["name"]
+    cfg["cpus"] = 42
+    save_defaults(cfg)
+    cfg2 = load_defaults()
+    assert cfg2["cpus"] == 42
+    assert "name" in KEY_TYPES


### PR DESCRIPTION
## Summary
- clarify `nslurm defaults set` usage and valid keys
- add tests for default-setting CLI
- factor out defaults into a module shared by CLI and API

## Testing
- `pip install textual -q`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c40844c7248326a788fa3f60de0381