### PR TITLE
feat: improve TUI navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ Most job parameters (such as cluster, time, or resource counts) have no built-in
 defaults. Set them explicitly on the command line or persist them via
 `nslurm defaults set`.
 
+View current jobs in an interactive TUI:
+
+```bash
+nslurm jobs
+```
+
+Use the arrow keys or `h`, `j`, `k`, `l` to move around and `q` to quit.
+
 ## Releasing
 
 Bump the version in `pyproject.toml` and merge the change into `main`. A

--- a/src/nanoslurm/tui.py
+++ b/src/nanoslurm/tui.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 
 from textual.app import App, ComposeResult
-from textual.widgets import DataTable
+from textual.widgets import DataTable, Footer, Header
 
 from .nanoslurm import SlurmUnavailableError, _run, _which
 
@@ -11,16 +11,39 @@ from .nanoslurm import SlurmUnavailableError, _run, _which
 class JobApp(App):
     """Textual app to display current user's SLURM jobs."""
 
-    BINDINGS = [("q", "quit", "Quit")]
+    BINDINGS = [
+        ("q", "quit", "Quit"),
+        ("h", "cursor_left", "Left"),
+        ("j", "cursor_down", "Down"),
+        ("k", "cursor_up", "Up"),
+        ("l", "cursor_right", "Right"),
+    ]
 
     def compose(self) -> ComposeResult:  # pragma: no cover - Textual composition
+        yield Header()
         self.table: DataTable = DataTable()
         yield self.table
+        yield Footer()
 
     def on_mount(self) -> None:  # pragma: no cover - runtime hook
         self.table.add_columns("ID", "Name", "State")
+        self.table.show_cursor = True
+        self.table.cursor_type = "row"
         self.refresh_table()
         self.set_interval(2.0, self.refresh_table)
+        self.set_focus(self.table)
+
+    def action_cursor_left(self) -> None:  # pragma: no cover - Textual action
+        self.table.action_cursor_left()
+
+    def action_cursor_right(self) -> None:  # pragma: no cover - Textual action
+        self.table.action_cursor_right()
+
+    def action_cursor_up(self) -> None:  # pragma: no cover - Textual action
+        self.table.action_cursor_up()
+
+    def action_cursor_down(self) -> None:  # pragma: no cover - Textual action
+        self.table.action_cursor_down()
 
     def refresh_table(self) -> None:  # pragma: no cover - runtime hook
         rows = _list_jobs()


### PR DESCRIPTION
## Summary
- add header/footer and vim-style navigation keys to SLURM job TUI
- document interactive TUI usage and key bindings

## Testing
- `ruff check src/nanoslurm/tui.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c40a519d38832681d5d8aba58af29b