### PR TITLE
Add cluster-wide statistics TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ nslurm jobs
 
 Use the arrow keys or `h`, `j`, `k`, `l` to move around and `q` to quit.
 
+View cluster-wide statistics such as job states and top users with counts and
+percentages. To query additional clusters, pass a comma-separated list via
+`--clusters`:
+
+```bash
+nslurm stats --clusters alpha,beta
+```
+
 ## Releasing
 
 Bump the version in `pyproject.toml` and merge the change into `main`. A

--- a/src/nanoslurm/cli.py
+++ b/src/nanoslurm/cli.py
@@ -86,6 +86,18 @@ def jobs() -> None:
     JobApp().run()
 
 
+@app.command("stats")
+def stats(
+    clusters: Optional[str] = typer.Option(
+        None, "--clusters", help="Comma-separated cluster names"
+    )
+) -> None:
+    """Launch a Textual TUI to view cluster-wide statistics."""
+    from .tui import ClusterApp
+
+    ClusterApp(clusters=clusters).run()
+
+
 defaults_app = typer.Typer(help="Manage default settings")
 app.add_typer(defaults_app, name="defaults")
 

--- a/src/nanoslurm/tui.py
+++ b/src/nanoslurm/tui.py
@@ -52,6 +52,40 @@ class JobApp(App):
             self.table.add_row(*row)
 
 
+class ClusterApp(App):
+    """Textual app to display cluster-wide job statistics."""
+
+    BINDINGS = [("q", "quit", "Quit")]
+
+    def __init__(self, clusters: str | None = None) -> None:
+        super().__init__()
+        self.clusters = clusters
+
+    def compose(self) -> ComposeResult:  # pragma: no cover - Textual composition
+        yield Header()
+        self.state_table: DataTable = DataTable()
+        yield self.state_table
+        self.user_table: DataTable = DataTable()
+        yield self.user_table
+        yield Footer()
+
+    def on_mount(self) -> None:  # pragma: no cover - runtime hook
+        self.state_table.add_columns("State", "Count", "Percent")
+        self.user_table.add_columns("User", "Jobs", "Percent")
+        self.refresh_tables()
+        self.set_interval(2.0, self.refresh_tables)
+
+    def refresh_tables(self) -> None:  # pragma: no cover - runtime hook
+        states = _cluster_job_state_counts(clusters=self.clusters)
+        users = _cluster_top_users(clusters=self.clusters)
+        self.state_table.clear()
+        for state, count, pct in states:
+            self.state_table.add_row(state, str(count), f"{pct:.1f}%")
+        self.user_table.clear()
+        for user, count, pct in users:
+            self.user_table.add_row(user, str(count), f"{pct:.1f}%")
+
+
 def _list_jobs() -> list[tuple[str, str, str]]:
     """Return a list of (id, name, state) for current user's jobs."""
     if not _which("squeue"):
@@ -66,4 +100,47 @@ def _list_jobs() -> list[tuple[str, str, str]]:
     return rows
 
 
-__all__ = ["JobApp"]
+def _cluster_job_state_counts(clusters: str | None = None) -> list[tuple[str, int, float]]:
+    """Return a list of (state, count, percent) for all jobs on the cluster."""
+    if not _which("squeue"):
+        raise SlurmUnavailableError("squeue command not found on PATH")
+    cmd = ["squeue", "-h", "-o", "%T"]
+    if clusters:
+        cmd.extend(["-M", clusters])
+    out = _run(cmd, check=False).stdout
+    counts: dict[str, int] = {}
+    for line in out.splitlines():
+        line = line.strip()
+        if line:
+            counts[line] = counts.get(line, 0) + 1
+    total = sum(counts.values()) or 1
+    return sorted(
+        [(state, count, round(count / total * 100, 1)) for state, count in counts.items()],
+        key=lambda x: x[0],
+    )
+
+
+def _cluster_top_users(
+    limit: int = 5, clusters: str | None = None
+) -> list[tuple[str, int, float]]:
+    """Return the top users by job count."""
+    if not _which("squeue"):
+        raise SlurmUnavailableError("squeue command not found on PATH")
+    cmd = ["squeue", "-h", "-o", "%u"]
+    if clusters:
+        cmd.extend(["-M", clusters])
+    out = _run(cmd, check=False).stdout
+    counts: dict[str, int] = {}
+    for line in out.splitlines():
+        line = line.strip()
+        if line:
+            counts[line] = counts.get(line, 0) + 1
+    total = sum(counts.values()) or 1
+    items = sorted(counts.items(), key=lambda x: (-x[1], x[0]))
+    result: list[tuple[str, int, float]] = []
+    for user, count in items[:limit]:
+        result.append((user, count, round(count / total * 100, 1)))
+    return result
+
+
+__all__ = ["JobApp", "ClusterApp"]

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -3,7 +3,11 @@ import types
 import pytest
 
 from nanoslurm.nanoslurm import SlurmUnavailableError
-from nanoslurm.tui import _list_jobs
+from nanoslurm.tui import (
+    _cluster_job_state_counts,
+    _cluster_top_users,
+    _list_jobs,
+)
 
 
 def test_list_jobs_no_squeue(monkeypatch):
@@ -20,4 +24,55 @@ def test_list_jobs_parse(monkeypatch):
 
     monkeypatch.setattr("nanoslurm.tui._run", fake_run)
     assert _list_jobs() == [("1", "job1", "RUNNING"), ("2", "job2", "PENDING")]
+
+
+def test_cluster_stats_no_squeue(monkeypatch):
+    monkeypatch.setattr("nanoslurm.tui._which", lambda cmd: False)
+    with pytest.raises(SlurmUnavailableError):
+        _cluster_job_state_counts()
+    with pytest.raises(SlurmUnavailableError):
+        _cluster_top_users()
+
+
+def test_cluster_job_state_counts_parse(monkeypatch):
+    monkeypatch.setattr("nanoslurm.tui._which", lambda cmd: True)
+
+    def fake_run(cmd, check=False):
+        return types.SimpleNamespace(stdout="RUNNING\nRUNNING\nPENDING\n")
+
+    monkeypatch.setattr("nanoslurm.tui._run", fake_run)
+    assert _cluster_job_state_counts() == [
+        ("PENDING", 1, 33.3),
+        ("RUNNING", 2, 66.7),
+    ]
+
+
+def test_cluster_top_users_parse(monkeypatch):
+    monkeypatch.setattr("nanoslurm.tui._which", lambda cmd: True)
+
+    def fake_run(cmd, check=False):
+        return types.SimpleNamespace(stdout="alice\nbob\nalice\n")
+
+    monkeypatch.setattr("nanoslurm.tui._run", fake_run)
+    assert _cluster_top_users(limit=10) == [
+        ("alice", 2, 66.7),
+        ("bob", 1, 33.3),
+    ]
+
+
+def test_cluster_commands_with_clusters(monkeypatch):
+    monkeypatch.setattr("nanoslurm.tui._which", lambda cmd: True)
+    captured: list[list[str]] = []
+
+    def fake_run(cmd, check=False):
+        captured.append(cmd)
+        return types.SimpleNamespace(stdout="")
+
+    monkeypatch.setattr("nanoslurm.tui._run", fake_run)
+    _cluster_job_state_counts(clusters="alpha,beta")
+    _cluster_top_users(clusters="alpha,beta")
+    assert [
+        ["squeue", "-h", "-o", "%T", "-M", "alpha,beta"],
+        ["squeue", "-h", "-o", "%u", "-M", "alpha,beta"],
+    ] == captured
 


### PR DESCRIPTION
## Summary
- add percentage breakdowns and multi-cluster support to ClusterApp TUI
- expose `--clusters` flag for `nslurm stats` command
- document stats percentages and multi-cluster usage

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c40e3d173483269cd468145995bdd6