### PR TITLE
Add partition stats to nslurm TUI and drop cluster option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,11 @@ nslurm jobs
 
 Use the arrow keys or `h`, `j`, `k`, `l` to move around and `q` to quit.
 
-View cluster-wide statistics such as job states and top users with counts and
-percentages. To query additional clusters, pass a comma-separated list via
-`--clusters`:
+View cluster-wide statistics such as job states, top users, and job counts by
+partition with counts and percentages:
 
 ```bash
-nslurm stats --clusters alpha,beta
+nslurm stats
 ```
 
 ## Releasing

--- a/src/nanoslurm/cli.py
+++ b/src/nanoslurm/cli.py
@@ -87,15 +87,11 @@ def jobs() -> None:
 
 
 @app.command("stats")
-def stats(
-    clusters: Optional[str] = typer.Option(
-        None, "--clusters", help="Comma-separated cluster names"
-    )
-) -> None:
+def stats() -> None:
     """Launch a Textual TUI to view cluster-wide statistics."""
     from .tui import ClusterApp
 
-    ClusterApp(clusters=clusters).run()
+    ClusterApp().run()
 
 
 defaults_app = typer.Typer(help="Manage default settings")


### PR DESCRIPTION
## Summary
- drop non-functional `--clusters` option from `nslurm stats`
- show partition job counts alongside state and user summaries in `nslurm stats`
- document updated statistics view

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c41505d1788326902b09f820d2420f