### PR TITLE
Trigger release only on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,9 @@
 name: Release
 
 on:
-  workflow_run:
-    workflows: ["Tag version"]
-    types:
-      - completed
+  push:
+    tags:
+      - "v*"
 
 permissions:
   contents: write
@@ -12,38 +11,21 @@ permissions:
 
 jobs:
   publish:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     environment: pypi
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.ref }}
       - uses: astral-sh/setup-uv@v4
         with:
           python-version: "3.11"
-      - name: Get version
-        id: version
-        run: |
-          echo "version=$(uv version --short)" >> "$GITHUB_OUTPUT"
-      - name: Check tag exists
-        id: tag
-        run: |
-          git fetch --tags
-          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
       - run: uv build
-        if: steps.tag.outputs.exists == 'true'
       - run: uv publish --check-url https://pypi.org/simple
-        if: steps.tag.outputs.exists == 'true'
       - name: Create GitHub release
-        if: steps.tag.outputs.exists == 'true'
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: v${{ steps.version.outputs.version }}
-          name: v${{ steps.version.outputs.version }}
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           files: dist/*


### PR DESCRIPTION
## Summary
- run release workflow only when a version tag is pushed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c414bf84f083269af718ca07d829de