### PR TITLE
fix: remove invalid workflow permission

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  workflows: write
 
 jobs:
   tag:


### PR DESCRIPTION
## Summary
- remove unsupported workflows permission in tagging workflow

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c428016bd483268508ad9e6313b3fd