### PR TITLE
Fix TUI DataTable CSS for Textual 6 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nanoslurm"
-version = "0.1.7"
+version = "0.1.8"
 description = "Zero-dependency Python wrapper for SLURM job submission and monitoring"
 readme = "README.md"
 authors = [

--- a/src/nanoslurm/tui.py
+++ b/src/nanoslurm/tui.py
@@ -11,26 +11,11 @@ from .backend import list_jobs
 # Use a minimal style that respects the user's terminal colors.  By default
 # Textual sets a dark theme that overrides the terminal background which makes
 # the TUI look out of place when launched in a customised terminal.  Setting the
-# background to ``default`` keeps the terminal's own colours and also applies
-# the same palette to headers, footers and tables.
+# background to ``default`` keeps the terminal's own colours for all widgets.
 BASE_CSS = """
-Screen {
+Screen, Header, Footer, DataTable {
     background: default;
     color: default;
-}
-Header, Footer {
-    background: default;
-    color: default;
-}
-DataTable {
-    background: default;
-    color: default;
-    --header-background: default;
-    --header-color: default;
-    --cursor-background: grey30;
-    --cursor-color: default;
-    --even-row-background: default;
-    --odd-row-background: grey23;
 }
 """
 
@@ -57,7 +42,6 @@ class JobApp(App):
         self.table.add_columns("ID", "Name", "State")
         self.table.show_cursor = True
         self.table.cursor_type = "row"
-        self.table.zebra_stripes = True
         self.refresh_table()
         self.set_interval(2.0, self.refresh_table)
         self.set_focus(self.table)
@@ -101,8 +85,6 @@ class ClusterApp(App):
         self.state_table.add_columns("State", "Count", "Percent")
         self.partition_table.add_columns("Partition", "Jobs", "Percent")
         self.user_table.add_columns("User", "Jobs", "Percent")
-        for table in (self.state_table, self.partition_table, self.user_table):
-            table.zebra_stripes = True
         self.refresh_tables()
         self.set_interval(2.0, self.refresh_tables)
 


### PR DESCRIPTION
## Summary
- simplify TUI styling to rely on default terminal colors
- bump project version to 0.1.8

## Testing
- `python -m ruff check src/nanoslurm/tui.py`
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src python - <<'PY'
from nanoslurm.tui import BASE_CSS
from textual.css import parse
parse.parse("", BASE_CSS, ("<inline>", ""))
print('parsed ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c42e6425a083268410bea398f86dac