### PR TITLE
feat: redesign stats TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ nslurm jobs
 
 Use the arrow keys or `h`, `j`, `k`, `l` to move around and `q` to quit.
 
-View cluster-wide statistics such as job states, top users, and job counts by
-partition with counts and percentages:
+View cluster-wide statistics with a summary overview and per-partition tabs.
+The TUI shows job states, user activity, and job distribution percentages:
 
 ```bash
 nslurm stats


### PR DESCRIPTION
## Summary
- redesign `nslurm stats` as tabbed TUI
- show full user and partition statistics with running/pending breakdowns
- document updated cluster stats view

## Testing
- `python -m ruff check src/nanoslurm/tui.py`

------
https://chatgpt.com/codex/tasks/task_e_68c4376b74c88326b9ec36320552148d