### PR TITLE
Add recent job completion summary UI

### DIFF
--- a/src/nanoslurm/backend.py
+++ b/src/nanoslurm/backend.py
@@ -4,8 +4,9 @@ import os
 import shlex
 import subprocess
 import time
+from collections import Counter
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Iterable, Optional, Sequence, Union
 
@@ -246,6 +247,51 @@ def list_jobs(user: Optional[str] = None) -> list[Job]:
     return rows
 
 
+def recent_completions(span: str = "day", count: int = 7) -> list[tuple[str, int]]:
+    """Return counts of recently completed jobs grouped by *span*.
+
+    Args:
+        span: Group results by ``"day"`` or ``"week"``.
+        count: Number of periods to return.
+
+    Returns:
+        List of (period, job_count) tuples sorted chronologically.
+    """
+    _require("sacct")
+    if span not in {"day", "week"}:
+        raise ValueError("span must be 'day' or 'week'")
+
+    delta = timedelta(days=count if span == "day" else count * 7)
+    start = (datetime.now() - delta).strftime("%Y-%m-%d")
+    cmd = [
+        "sacct",
+        "--state=CD",
+        "--noheader",
+        "--parsable2",
+        "--format=End",
+        f"--starttime={start}",
+        "-X",
+    ]
+    out = _run(cmd, check=False).stdout
+    counts: Counter[str] = Counter()
+    for line in out.splitlines():
+        token = line.strip()
+        if not token:
+            continue
+        try:
+            dt = datetime.strptime(token.split(".")[0], "%Y-%m-%dT%H:%M:%S")
+        except ValueError:
+            continue
+        if span == "week":
+            year, week, _ = dt.isocalendar()
+            key = f"{year}-W{week:02d}"
+        else:
+            key = dt.strftime("%Y-%m-%d")
+        counts[key] += 1
+    items = sorted(counts.items())
+    return items[-count:]
+
+
 def _squeue_status(job_id: int) -> Optional[str]:
     if not _which("squeue"):
         return None
@@ -288,4 +334,5 @@ __all__ = [
     "SlurmUnavailableError",
     "submit",
     "list_jobs",
+    "recent_completions",
 ]

--- a/src/nanoslurm/cli.py
+++ b/src/nanoslurm/cli.py
@@ -94,6 +94,14 @@ def stats() -> None:
     ClusterApp().run()
 
 
+@app.command("summary")
+def summary() -> None:
+    """Launch a Textual TUI summarizing recent completions."""
+    from .tui import SummaryApp
+
+    SummaryApp().run()
+
+
 defaults_app = typer.Typer(help="Manage default settings")
 app.add_typer(defaults_app, name="defaults")
 

--- a/src/nanoslurm/tui.py
+++ b/src/nanoslurm/tui.py
@@ -6,7 +6,7 @@ from collections import Counter
 from textual.app import App, ComposeResult
 from textual.widgets import DataTable, Footer, Header
 
-from .backend import list_jobs
+from .backend import list_jobs, recent_completions
 
 BASE_CSS = ""
 
@@ -108,4 +108,42 @@ class ClusterApp(App):
             self.user_table.add_row(user, str(count), f"{pct:.1f}%")
 
 
-__all__ = ["JobApp", "ClusterApp"]
+class SummaryApp(App):
+    """Textual app to display recent job completions."""
+
+    CSS = BASE_CSS
+    BINDINGS = [("q", "quit", "Quit")]
+
+    def compose(self) -> ComposeResult:  # pragma: no cover - Textual composition
+        yield Header()
+        self.day_table: DataTable = DataTable()
+        yield self.day_table
+        self.week_table: DataTable = DataTable()
+        yield self.week_table
+        yield Footer()
+
+    def on_mount(self) -> None:  # pragma: no cover - runtime hook
+        self.day_table.add_columns("Day", "Jobs", "Spark")
+        self.week_table.add_columns("Week", "Jobs", "Spark")
+        self.refresh_tables()
+        self.set_interval(60.0, self.refresh_tables)
+
+    def refresh_tables(self) -> None:  # pragma: no cover - runtime hook
+        day_rows = recent_completions("day", 7)
+        week_rows = recent_completions("week", 8)
+
+        def _add_rows(table: DataTable, rows: list[tuple[str, int]]) -> None:
+            table.clear()
+            if not rows:
+                return
+            max_count = max(cnt for _, cnt in rows) or 1
+            levels = "▁▂▃▄▅▆▇█"
+            for label, cnt in rows:
+                idx = int(cnt / max_count * (len(levels) - 1))
+                table.add_row(label, str(cnt), levels[idx])
+
+        _add_rows(self.day_table, day_rows)
+        _add_rows(self.week_table, week_rows)
+
+
+__all__ = ["JobApp", "ClusterApp", "SummaryApp"]


### PR DESCRIPTION
## Summary
- add `recent_completions` helper to query `sacct` for completed jobs
- display daily and weekly completion counts in new SummaryApp TUI
- expose `nslurm summary` CLI command to launch the summary view

## Testing
- `python -m ruff check .`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c440ea7968832681940d1d4322e5e0