### PR TITLE
feat: unify TUIs into single dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,21 +82,18 @@ Most job parameters (such as cluster, time, or resource counts) have no built-in
 defaults. Set them explicitly on the command line or persist them via
 `nslurm defaults set`.
 
-View current jobs in an interactive TUI:
+View jobs and cluster statistics in an interactive TUI:
 
 ```bash
-nslurm jobs
+nslurm monitor
 ```
 
 Use the arrow keys or `h`, `j`, `k`, `l` to move around and `q` to quit.
 
-
-View cluster-wide statistics with a summary overview and per-partition tabs.
-The TUI shows node states, job states, user activity, and job counts by partition with percentages:
-
+View recent job completions:
 
 ```bash
-nslurm stats
+nslurm history
 ```
 
 ## Releasing

--- a/src/nanoslurm/cli.py
+++ b/src/nanoslurm/cli.py
@@ -78,25 +78,17 @@ def run(
         console.print(f"stderr: {job.stderr_path}")
 
 
-@app.command("jobs")
-def jobs() -> None:
-    """Launch a Textual TUI to view current user's jobs."""
-    from .tui import JobApp
+@app.command("monitor")
+def monitor() -> None:
+    """Launch a dashboard for jobs and cluster statistics."""
+    from .tui import DashboardApp
 
-    JobApp().run()
-
-
-@app.command("stats")
-def stats() -> None:
-    """Launch a Textual TUI to view cluster-wide statistics."""
-    from .tui import ClusterApp
-
-    ClusterApp().run()
+    DashboardApp().run()
 
 
-@app.command("summary")
-def summary() -> None:
-    """Launch a Textual TUI summarizing recent completions."""
+@app.command("history")
+def history() -> None:
+    """Launch a TUI summarizing recent job completions."""
     from .tui import SummaryApp
 
     SummaryApp().run()


### PR DESCRIPTION
## Summary
- merge job and cluster stats TUIs into one dashboard with Jobs as the default tab
- rename CLI commands to `monitor` for the dashboard and `history` for recent completions
- update docs to reference new commands
- remove unused `gap` style from partition pane CSS

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5164a6d0c832694eba8c922d6709d