### PR TITLE
refactor: centralize job querying and simplify command handling

### DIFF
--- a/src/nanoslurm/_slurm.py
+++ b/src/nanoslurm/_slurm.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 """Thin wrappers around SLURM commands with explicit keyword-based options."""
 
-from subprocess import CompletedProcess
 from shutil import which
 from typing import Sequence
 
-from .utils import run_command
+from .utils.cmd import run_command
 
 
 class SlurmUnavailableError(RuntimeError):
@@ -18,19 +17,6 @@ def require(cmd: str, which_func=which) -> None:
         raise SlurmUnavailableError(
             f"Required command '{cmd}' not found. Is this a SLURM environment?"
         )
-
-
-def run(cmd: Sequence[str], check: bool = True) -> CompletedProcess:
-    """Execute *cmd* using :func:`utils.cmd.run_command`.
-
-    This wrapper ensures consistent logging and retry behaviour across the
-    project while maintaining the original return type from
-    :func:`subprocess.run`.
-    """
-
-    return run_command(cmd, check=check)
-
-
 def normalize_state(state: str) -> str:
     """Normalize a SLURM state string.
 
@@ -49,7 +35,7 @@ def _table(
     keys: Sequence[str],
     sep: str | None,
     *,
-    runner=run,
+    runner=run_command,
 ) -> list[dict[str, str]]:
     out = runner(cmd, check=False).stdout
     rows: list[dict[str, str]] = []
@@ -86,7 +72,7 @@ def squeue(
     partitions: Sequence[str] | None = None,
     states: Sequence[str] | None = None,
     sort: str | None = None,
-    runner=run,
+    runner=run_command,
     which_func=which,
     check: bool = True,
 ) -> list[dict[str, str]]:
@@ -136,7 +122,7 @@ def sacct(
     end_time: str | None = None,
     all_users: bool = False,
     allocations: bool = False,
-    runner=run,
+    runner=run_command,
     which_func=which,
     check: bool = True,
 ) -> list[dict[str, str]]:
@@ -185,7 +171,7 @@ def sinfo(
     partitions: Sequence[str] | None = None,
     states: Sequence[str] | None = None,
     all_partitions: bool = False,
-    runner=run,
+    runner=run_command,
     which_func=which,
     check: bool = True,
 ) -> list[dict[str, str]]:
@@ -221,7 +207,7 @@ def sprio(
     fields: Sequence[str] = ("job_id", "user", "priority"),
     jobs: Sequence[int] | None = None,
     users: Sequence[str] | None = None,
-    runner=run,
+    runner=run_command,
     which_func=which,
     check: bool = True,
 ) -> list[dict[str, str]]:
@@ -254,7 +240,7 @@ def sshare(
     fields: Sequence[str] = ("user", "fairshare"),
     users: Sequence[str] | None = None,
     accounts: Sequence[str] | None = None,
-    runner=run,
+    runner=run_command,
     which_func=which,
     check: bool = True,
 ) -> list[dict[str, str]]:
@@ -274,7 +260,6 @@ def sshare(
 
 __all__ = [
     "SlurmUnavailableError",
-    "run",
     "normalize_state",
     "which",
     "require",

--- a/tests/test_fairshare.py
+++ b/tests/test_fairshare.py
@@ -12,7 +12,7 @@ def test_fairshare_scores_sprio(monkeypatch):
     monkeypatch.setattr(stats, "_which", lambda cmd: cmd == "sprio")
     monkeypatch.setattr(
         stats,
-        "_run",
+        "run_command",
         lambda cmd, check=False: types.SimpleNamespace(stdout="alice 0.5\nbob 0.1\n"),
     )
     assert fairshare_scores() == {"alice": 0.5, "bob": 0.1}
@@ -22,7 +22,7 @@ def test_fairshare_scores_sshare(monkeypatch):
     monkeypatch.setattr(stats, "_which", lambda cmd: cmd == "sshare")
     monkeypatch.setattr(
         stats,
-        "_run",
+        "run_command",
         lambda cmd, check=False: types.SimpleNamespace(stdout="carol 0.7\n"),
     )
     assert fairshare_scores() == {"carol": 0.7}

--- a/tests/test_partition_caps.py
+++ b/tests/test_partition_caps.py
@@ -17,8 +17,7 @@ def test_partition_caps_gpu_total(monkeypatch):
     def fake_run(cmd, check=False):
         return Dummy(stdout=sinfo_out)
 
-    monkeypatch.setattr(stats, "_run", fake_run)
-    monkeypatch.setattr(stats, "_require", lambda cmd: None)
+    monkeypatch.setattr(stats, "run_command", fake_run)
 
     caps = stats._partition_caps()
     assert caps["p1"]["gpus"] == 16

--- a/tests/test_state_normalization.py
+++ b/tests/test_state_normalization.py
@@ -18,7 +18,7 @@ def test_normalize_state_cases():
 
 
 def test_list_jobs_state_normalization(monkeypatch):
-    def fake_squeue(*, fields, **kwargs):
+    def fake_fetch(*, fields, **kwargs):
         return [
             {
                 "id": "1",
@@ -31,8 +31,7 @@ def test_list_jobs_state_normalization(monkeypatch):
             }
         ]
 
-    monkeypatch.setattr(job, "_squeue", fake_squeue)
-    monkeypatch.setattr(job, "_which", lambda cmd: cmd == "squeue")
+    monkeypatch.setattr(job, "_fetch", fake_fetch)
     rows = job.list_jobs()
     assert rows[0].last_status == "RUNNING"
 


### PR DESCRIPTION
## Summary
- replace custom run wrapper with direct `run_command` usage
- centralize job lookup via new `_fetch` helper
- simplify log tailing and update tests for refactored interfaces

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6a880737c83269ff280f4b530bb74