### PR TITLE
Streamline TUI to stats-only interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,19 +82,13 @@ Most job parameters (such as cluster, time, or resource counts) have no built-in
 defaults. Set them explicitly on the command line or persist them via
 `nslurm defaults set`.
 
-View jobs and cluster statistics in an interactive TUI:
+View cluster statistics in an interactive TUI:
 
 ```bash
-nslurm monitor
+nslurm stats
 ```
 
 Use the arrow keys or `h`, `j`, `k`, `l` to move around and `q` to quit.
-
-View recent job completions:
-
-```bash
-nslurm history
-```
 
 ## Releasing
 

--- a/src/nanoslurm/cli.py
+++ b/src/nanoslurm/cli.py
@@ -8,7 +8,6 @@ import yaml
 from rich.console import Console
 from rich.table import Table
 
-from .job import submit
 from .defaults import (
     CONFIG_PATH,
     DEFAULTS,
@@ -17,6 +16,7 @@ from .defaults import (
     load_defaults,
     save_defaults,
 )
+from .job import submit
 
 app = typer.Typer(help="Submit and manage jobs with nanoslurm")
 console = Console()
@@ -78,20 +78,12 @@ def run(
         console.print(f"stderr: {job.stderr_path}")
 
 
-@app.command("monitor")
-def monitor() -> None:
-    """Launch a dashboard for jobs and cluster statistics."""
-    from .tui import DashboardApp
+@app.command("stats")
+def stats() -> None:
+    """Launch a TUI showing cluster statistics."""
+    from .tui import StatsApp
 
-    DashboardApp().run()
-
-
-@app.command("history")
-def history() -> None:
-    """Launch a TUI summarizing recent job completions."""
-    from .tui import SummaryApp
-
-    SummaryApp().run()
+    StatsApp().run()
 
 
 defaults_app = typer.Typer(help="Manage default settings")

--- a/src/nanoslurm/tui.py
+++ b/src/nanoslurm/tui.py
@@ -1,22 +1,13 @@
 from __future__ import annotations
 
-import os
 from collections import Counter, defaultdict
-from datetime import timedelta
 
 from textual.app import App, ComposeResult
-from textual.containers import Grid, Vertical
-from textual.widgets import DataTable, Footer, Header, TabbedContent, TabPane
+from textual.containers import Grid
+from textual.widgets import DataTable, Footer, Header
 
 from .job import list_jobs
-from .stats import (
-    fairshare_scores,
-    job_history,
-    node_state_counts,
-    partition_node_state_counts,
-    partition_utilization,
-    recent_completions,
-)
+from .stats import fairshare_scores, node_state_counts, partition_utilization
 
 BASE_CSS = """
 Screen {
@@ -30,17 +21,11 @@ Screen {
 #summary-grid DataTable {
     width: 100%;
 }
-.partition-pane {
-    layout: vertical;
-}
-.partition-pane DataTable {
-    width: 100%;
-}
 """
 
 
-class DashboardApp(App):
-    """Combined TUI showing user jobs and cluster statistics."""
+class StatsApp(App):
+    """Textual app to display cluster statistics."""
 
     CSS = BASE_CSS
     BINDINGS = [
@@ -57,51 +42,26 @@ class DashboardApp(App):
 
     def compose(self) -> ComposeResult:  # pragma: no cover - Textual composition
         yield Header()
-        with TabbedContent() as self.main_tabs:
-            with TabPane("Jobs"):
-                self.job_table = DataTable()
-                yield self.job_table
-            with TabPane("Cluster"):
-                self.cluster_tabs = TabbedContent()
-                with self.cluster_tabs:
-                    with TabPane("Summary"):
-                        with Grid(id="summary-grid"):
-                            self.partition_table = DataTable()
-                            self.user_table = DataTable()
-                            self.state_table = DataTable()
-                            self.node_table = DataTable()
-                            yield self.partition_table
-                            yield self.user_table
-                            yield self.state_table
-                            yield self.node_table
+        with Grid(id="summary-grid"):
+            self.partition_table = DataTable()
+            self.user_table = DataTable()
+            self.state_table = DataTable()
+            self.node_table = DataTable()
+            yield self.partition_table
+            yield self.user_table
+            yield self.state_table
+            yield self.node_table
         yield Footer()
 
     def on_mount(self) -> None:  # pragma: no cover - runtime hook
-        self.job_table.add_columns("ID", "Name", "State")
-        self.job_table.show_cursor = True
-        self.job_table.cursor_type = "row"
-
         self.node_table.add_columns("State", "Nodes", "Percent")
         self.state_table.add_columns("State", "Jobs", "Percent")
         self.partition_table.add_columns("Partition", "Jobs", "Running", "Pending", "Share%", "Util%")
-        self.user_table.add_columns(
-            "User",
-            "Jobs",
-            "Running",
-            "Pending",
-            "Share%",
-            "FairShare",
-            "Succeeded (24h)",
-            "Failed (24h)",
-        )
+        self.user_table.add_columns("User", "Jobs", "Running", "Pending", "Share%", "FairShare")
 
-        self.partition_tables: dict[str, dict[str, DataTable]] = {}
-
-        self.refresh_jobs()
-        self.refresh_cluster()
-        self.set_interval(2.0, self.refresh_jobs)
-        self.set_interval(2.0, self.refresh_cluster)
-        self.set_focus(self.job_table)
+        self.refresh_stats()
+        self.set_interval(2.0, self.refresh_stats)
+        self.set_focus(self.partition_table)
 
     def _focused_table(self) -> DataTable | None:
         widget = self.focused
@@ -123,13 +83,7 @@ class DashboardApp(App):
         if (table := self._focused_table()) is not None:
             table.action_cursor_down()
 
-    def refresh_jobs(self) -> None:  # pragma: no cover - runtime hook
-        rows = list_jobs(os.environ.get("USER"))
-        self.job_table.clear()
-        for job in rows:
-            self.job_table.add_row(str(job.id), job.name, job.last_status or job.status)
-
-    def refresh_cluster(self) -> None:  # pragma: no cover - runtime hook
+    def refresh_stats(self) -> None:  # pragma: no cover - runtime hook
         node_counts = node_state_counts()
         total_nodes = sum(node_counts.values()) or 1
 
@@ -151,13 +105,7 @@ class DashboardApp(App):
         except Exception:  # pragma: no cover - runtime environment
             util_map = {}
 
-        try:
-            node_map = partition_node_state_counts()
-        except Exception:  # pragma: no cover - runtime environment
-            node_map = {}
-
         shares = fairshare_scores()
-        history = job_history()
 
         self.node_table.clear()
         for state, count in sorted(node_counts.items()):
@@ -177,49 +125,13 @@ class DashboardApp(App):
             share = jobs / total_jobs * 100
             util = util_map.get(part, 0.0)
             self.partition_table.add_row(
-                part, str(jobs), str(running), str(pending), f"{share:.1f}%", f"{util:.1f}%"
+                part,
+                str(jobs),
+                str(running),
+                str(pending),
+                f"{share:.1f}%",
+                f"{util:.1f}%",
             )
-            if part not in self.partition_tables:
-                stats_table = DataTable()
-                stats_table.add_columns("Metric", "Value")
-                user_table = DataTable()
-                user_table.add_columns("User", "Jobs", "Running", "Pending", "Share%")
-                pane = TabPane(part, Vertical(stats_table, user_table, classes="partition-pane"))
-                self.cluster_tabs.add_pane(pane)
-                self.partition_tables[part] = {"stats": stats_table, "users": user_table}
-
-        for part, tables in self.partition_tables.items():
-            u_stats: defaultdict[str, Counter] = defaultdict(Counter)
-            for job in job_list:
-                if job.partition != part:
-                    continue
-                u_stats[job.user]["jobs"] += 1
-                u_stats[job.user][job.last_status] += 1
-            total_part = sum(s["jobs"] for s in u_stats.values()) or 1
-            user_table = tables["users"]
-            user_table.clear()
-            for user, cnts in sorted(u_stats.items(), key=lambda x: (-x[1]["jobs"], x[0])):
-                jobs = cnts["jobs"]
-                running = cnts.get("RUNNING", 0)
-                pending = cnts.get("PENDING", 0)
-                share = jobs / total_part * 100
-                user_table.add_row(user, str(jobs), str(running), str(pending), f"{share:.1f}%")
-
-            stats_table = tables["stats"]
-            stats_table.clear()
-            counts = node_map.get(part)
-            if counts:
-                free_nodes = counts.get("IDLE", 0)
-                total_part_nodes = sum(counts.values())
-                stats_table.add_row("free nodes", str(free_nodes))
-                stats_table.add_row("total nodes", str(total_part_nodes))
-            else:
-                stats_table.add_row("free nodes", "unavailable")
-            util = util_map.get(part)
-            if util is not None:
-                stats_table.add_row("util%", f"{util:.1f}%")
-            else:
-                stats_table.add_row("util%", "unavailable")
 
         self.user_table.clear()
         for user, cnts in sorted(user_stats.items(), key=lambda x: (-x[1]["jobs"], x[0]))[:5]:
@@ -229,7 +141,6 @@ class DashboardApp(App):
             share = jobs / total_jobs * 100
             fs = shares.get(user)
             fs_str = f"{fs:.3f}" if isinstance(fs, float) else "N/A"
-            hist = history.get(user, {"completed": 0, "failed": 0})
             self.user_table.add_row(
                 user,
                 str(jobs),
@@ -237,52 +148,7 @@ class DashboardApp(App):
                 str(pending),
                 f"{share:.1f}%",
                 fs_str,
-                str(hist.get("completed", 0)),
-                str(hist.get("failed", 0)),
             )
 
 
-class SummaryApp(App):
-    """Textual app to display recent job completions."""
-
-    CSS = BASE_CSS
-    BINDINGS = [("q", "quit", "Quit")]
-
-    def __init__(self, **kwargs):
-        kwargs.setdefault("ansi_color", True)
-        super().__init__(**kwargs)
-
-    def compose(self) -> ComposeResult:  # pragma: no cover - Textual composition
-        yield Header()
-        self.day_table: DataTable = DataTable()
-        yield self.day_table
-        self.week_table: DataTable = DataTable()
-        yield self.week_table
-        yield Footer()
-
-    def on_mount(self) -> None:  # pragma: no cover - runtime hook
-        self.day_table.add_columns("Day", "Jobs", "Spark")
-        self.week_table.add_columns("Week", "Jobs", "Spark")
-        self.refresh_tables()
-        self.set_interval(60.0, self.refresh_tables)
-
-    def refresh_tables(self) -> None:  # pragma: no cover - runtime hook
-        day_rows = recent_completions("day", 7)
-        week_rows = recent_completions("week", 8)
-
-        def _add_rows(table: DataTable, rows: list[tuple[str, int]]) -> None:
-            table.clear()
-            if not rows:
-                return
-            max_count = max(cnt for _, cnt in rows) or 1
-            levels = "▁▂▃▄▅▆▇█"
-            for label, cnt in rows:
-                idx = int(cnt / max_count * (len(levels) - 1))
-                table.add_row(label, str(cnt), levels[idx])
-
-        _add_rows(self.day_table, day_rows)
-        _add_rows(self.week_table, week_rows)
-
-
-__all__ = ["DashboardApp", "SummaryApp"]
-
+__all__ = ["StatsApp"]


### PR DESCRIPTION
## Summary
- Replace `monitor` and `history` commands with a single `stats` command
- Implement lightweight `StatsApp` TUI focused on cluster statistics
- Update README to document `nslurm stats`

## Testing
- ⚠️ `ruff check .` (import block errors in unrelated files)
- ✅ `ruff check src/nanoslurm/cli.py src/nanoslurm/tui.py`
- ✅ `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7010abfe083269a5c982b247afb3d