### PR TITLE
Enable automatic release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,4 +61,5 @@ jobs:
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: v${{ steps.version.outputs.version }}
+          generate_release_notes: true
           files: dist/*


### PR DESCRIPTION
## Summary
- update the release workflow to request generated release notes when publishing a tag
- rely on GitHub's automatic notes so each release includes a summary of merged work

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c92af8e56c8326a4a658b997bfcca9