### PR TITLE
Enable ANSI colors in monitor TUI

### DIFF
--- a/src/nanoslurm/tui.py
+++ b/src/nanoslurm/tui.py
@@ -326,6 +326,10 @@ class PartitionScreen(Screen[None]):
 class MonitorApp(App[None]):
     """Application orchestrating the monitor screens."""
 
+    def __init__(self, **kwargs):
+        kwargs.setdefault("ansi_color", True)
+        super().__init__(**kwargs)
+
     TITLE = LOGO
     SUB_TITLE = ""
 


### PR DESCRIPTION
## Summary
- default the monitor application to ANSI colors by passing ansi_color=True to the Textual App base class

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68c9acb22c008326bd48837d17c63ded